### PR TITLE
[16.0] Fix stock_barcodes: prevents multiple scans

### DIFF
--- a/stock_barcodes/tests/__init__.py
+++ b/stock_barcodes/tests/__init__.py
@@ -2,3 +2,4 @@
 from . import test_stock_barcodes
 from . import test_stock_barcodes_new_lot
 from . import test_stock_barcodes_picking
+from . import test_stock_barcodes_double_scan

--- a/stock_barcodes/tests/test_stock_barcodes_double_scan.py
+++ b/stock_barcodes/tests/test_stock_barcodes_double_scan.py
@@ -1,0 +1,36 @@
+from odoo.tests.common import tagged
+
+from .common import TestCommonStockBarcodes
+
+
+@tagged("post_install", "-at_install")
+class TestBarcodeDoubleScan(TestCommonStockBarcodes):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.option_group.pick_in_child_location = True
+        cls.option_group.show_pending_moves = True
+        cls.quant = cls.StockQuant.create(
+            {
+                "product_id": cls.product_wo_tracking.id,
+                "location_id": cls.location_1.id,
+                "quantity": 10.0,
+            }
+        )
+
+    def test_qty_available_without_pending_move_line(self):
+        """A product whose demand is already satisfied has no pending move line."""
+        wiz = self.WizScanReadPicking.create(
+            {"option_group_id": self.option_group.id, "step": 1}
+        )
+        wiz.location_id = self.location_1
+        wiz.product_id = self.product_wo_tracking
+
+        self.assertTrue(self.option_group.pick_in_child_location)
+        self.assertFalse(
+            wiz.pending_move_ids.line_ids.filtered(
+                lambda line: line.product_id == self.product_wo_tracking
+            )
+        )
+        self.assertEqual(wiz.location_id.usage, "internal")
+        self.assertEqual(wiz.qty_available, 10.0)

--- a/stock_barcodes/wizard/stock_barcodes_read.py
+++ b/stock_barcodes/wizard/stock_barcodes_read.py
@@ -127,28 +127,25 @@ class WizStockBarcodesRead(models.AbstractModel):
         if not self.product_id or self.location_id.usage != "internal":
             self.qty_available = 0.0
             return
+        domain_quant = [
+            ("product_id", "=", self.product_id.id),
+            ("location_id", "=", self.location_id.id),
+        ]
         if self.option_group_id.pick_in_child_location and self.product_id:
             candidate_move_line = self.pending_move_ids.line_ids.filtered(
                 lambda x: x.product_id.id == self.product_id.id
             )
-            if len(candidate_move_line) > 0:
+            if candidate_move_line:
                 domain_quant = [
                     ("product_id", "=", self.product_id.id),
                     ("location_id", "in", [candidate_move_line.location_id.id]),
                 ]
-        else:
-            domain_quant = [
-                ("product_id", "=", self.product_id.id),
-                ("location_id", "=", self.location_id.id),
-            ]
         if self.lot_id:
             domain_quant.append(("lot_id", "=", self.lot_id.id))
-        # if self.package_id:
-        #     domain_quant.append(('package_id', '=', self.package_id.id))
         groups = self.env["stock.quant"].read_group(
             domain_quant, ["quantity"], [], orderby="id"
         )
-        self.qty_available = groups[0]["quantity"]
+        self.qty_available = groups[0]["quantity"] or 0.0
 
     @api.depends("product_id")
     def _compute_display_assign_serial(self):


### PR DESCRIPTION
Prevents the scanner from scanning a quantity of product greater than the quantity requested

```
  File "/odoo/links/stock_barcodes/wizard/stock_barcodes_read.py", line 227, in process_barcode_product_id
    self.action_confirm()
  File "/odoo/links/stock_barcodes/wizard/stock_barcodes_read.py", line 800, in action_confirm
    res = self.action_done()
  File "/odoo/links/stock_barcodes/wizard/stock_barcodes_read_picking.py", line 274, in action_done
    ).action_done()
  File "/odoo/links/stock_barcodes/wizard/stock_barcodes_read.py", line 604, in action_done
    if not self.check_done_conditions():
  File "/odoo/links/stock_barcodes/wizard/stock_barcodes_read_picking.py", line 693, in check_done_conditions
    self.qty_available,
  File "/odoo/src/odoo/fields.py", line 1220, in __get__
    self.compute_value(recs)
  File "/odoo/src/odoo/fields.py", line 1402, in compute_value
    records._compute_field_value(self)
  File "/odoo/src/odoo/models.py", line 4276, in _compute_field_value
    fields.determine(field.compute, self)
  File "/odoo/src/odoo/fields.py", line 98, in determine
    return needle(*args)
  File "/odoo/links/stock_barcodes/wizard/stock_barcodes_read.py", line 149, in _compute_qty_available
    domain_quant, ["quantity"], [], orderby="id"
UnboundLocalError: local variable 'domain_quant' referenced before assignment```